### PR TITLE
Create Publication_PLUGIN_REPO_OFFICIEL.yml

### DIFF
--- a/.github/workflows/Publication_PLUGIN_REPO_OFFICIEL.yml
+++ b/.github/workflows/Publication_PLUGIN_REPO_OFFICIEL.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Deploy plugin to QGIS and GitHub
         run: |
-          qgis-plugin-ci release "${GITHUB_REF_NAME}" \
+          qgis-plugin-ci release "${GITHUB_REF/refs\/tags\//}" \
             --github-token "${{ secrets.GITHUB_TOKEN }}" \
             --osgeo-username "${{ secrets.OSGEO_USER }}" \
             --osgeo-password "${{ secrets.OSGEO_PASSWORD }}"


### PR DESCRIPTION
Action GitHub pour la publication automatique sur le dépôt officiel des plugins QGIS. Cette action n'a pas encore pu être testée.