### PR TITLE
corrections pour issue #75 de pluginHelper

### DIFF
--- a/Contexte.py
+++ b/Contexte.py
@@ -447,7 +447,7 @@ class Contexte(object):
         dlgInfo.textInfo.append("<br/>Serveur : {}".format(self.urlHostEspaceCo))
         dlgInfo.textInfo.append("Login : {}".format(self.getUserNameCommunity()))
         dlgInfo.textInfo.append("Groupe : {}".format(self.getUserCommunity().getName()))
-        zoneExtraction = PluginHelper.load_CalqueFiltrage(self.projectDir).text
+        zoneExtraction = PluginHelper.load_XmlTag(self.projectDir, PluginHelper.xml_Zone_extraction, PluginHelper.xml_Map).text
         if zoneExtraction == "" or zoneExtraction is None or len(
                 self.QgsProject.instance().mapLayersByName(zoneExtraction)) == 0:
             dlgInfo.textInfo.append("Zone de travail : pas de zone définie")

--- a/FormChargerGuichet.py
+++ b/FormChargerGuichet.py
@@ -251,7 +251,7 @@ class FormChargerGuichet(QtWidgets.QDialog, FORM_CLASS):
 
             # Filtre spatial (la zone de travail)
             bbox = BBox(self.__context)
-            box = bbox.getFromLayer(PluginHelper.load_CalqueFiltrage(self.__context.projectDir).text, False, True)
+            box = bbox.getFromLayer(PluginHelper.load_XmlTag(self.__context.projectDir, PluginHelper.xml_Zone_extraction, PluginHelper.xml_Map).text, False, True)
             # si la box est à None alors, l'utilisateur veut extraire France entière
             # si la box est égale 0.0 pour ces 4 coordonnées alors l'utilisateur
             # ne souhaite pas extraire les données France entière

--- a/PluginHelper.py
+++ b/PluginHelper.py
@@ -326,7 +326,7 @@ class PluginHelper:
             parentNode = PluginHelper.addXmlElement(projectDir, parentElem, PluginHelper.xml_Root)
         elementNode = ET.SubElement(parentNode, elem)
         if value is not None:
-            elementNode.text = value
+            elementNode.text = str(value)
         tree.write(projectDir + "/" + PluginHelper.getConfigFile(), encoding="utf-8")
         return elementNode
 
@@ -489,7 +489,9 @@ class PluginHelper:
             tree = PluginHelper.checkXmlFile(projectDir)
             xmlroot = tree.getroot()
             node = xmlroot.find(PluginHelper.getXPath(tag, parentTag))
-            node.text = value
+            if node is None:
+                node = PluginHelper.addXmlElement(projectDir, tag, parentTag)
+            node.text = str(value) if value is not None else ""
             tree.write(projectDir + "/" + PluginHelper.getConfigFile(), encoding="utf-8")
 
         except Exception as e:

--- a/PluginModule.py
+++ b/PluginModule.py
@@ -442,7 +442,7 @@ class RipartPlugin:
 
         :return: message de fin de transaction
         """
-        wfsPost = WfsPost(self.__context, layer, PluginHelper.load_CalqueFiltrage(self.__context.projectDir).text)
+        wfsPost = WfsPost(self.__context, layer, PluginHelper.load_XmlTag(self.__context.projectDir, PluginHelper.xml_Zone_extraction, PluginHelper.xml_Map).text)
         # Juste avant la sauvegarde de QGIS, les modifications d'une couche sont envoyées au serveur,
         # le buffer est vidé, il ne faut pas laisser QGIS vider le buffer une deuxième fois sinon plantage
         bNormalWfsPost = False
@@ -886,7 +886,7 @@ class RipartPlugin:
             progress.setValue(1)
             headers = {
                 'Authorization': '{} {}'.format(self.__context.getTokenType(), self.__context.getTokenAccess())}
-            spatialFilterName = PluginHelper.load_CalqueFiltrage(self.__context.projectDir).text
+            spatialFilterName = PluginHelper.load_XmlTag(self.__context.projectDir, PluginHelper.xml_Zone_extraction, PluginHelper.xml_Map).text
             i = 0
             for layer in layersToSynchronize:
                 i += 1

--- a/ToolsReport.py
+++ b/ToolsReport.py
@@ -92,7 +92,7 @@ class ToolsReport(object):
         """
         # filtre spatial
         bbox = BBox(self.__context)
-        box = bbox.getFromLayer(PluginHelper.load_CalqueFiltrage(self.__context.projectDir).text, True, True)
+        box = bbox.getFromLayer(PluginHelper.load_XmlTag(self.__context.projectDir, PluginHelper.xml_Zone_extraction, PluginHelper.xml_Map).text, True, True)
         # si la box est à None alors, l'utilisateur veut extraire France entière
         # si la box est égale 0.0 pour ces 4 coordonnées alors l'utilisateur
         # ne souhaite pas extraire les données France entière
@@ -133,7 +133,7 @@ class ToolsReport(object):
 
         # Récupération du calque de filtrage
         layerFilter = self.__context.getLayerByName(
-            PluginHelper.load_CalqueFiltrage(self.__context.projectDir).text
+            PluginHelper.load_XmlTag(self.__context.projectDir, PluginHelper.xml_Zone_extraction, PluginHelper.xml_Map).text
         )
 
         if layerFilter is None or layerFilter.featureCount() == 0:


### PR DESCRIPTION
changement de PluginHelper.load_CalqueFiltrage, vers load_XmlTag pour gérer le cas où il ne retrouve pas une balise XML.
plus une correction pour récupérer le login et string.

Permet de gérer les anciennes cartes faites avec une structure XML espace co différente