### PR TITLE
gestion des enumeres de type int

### DIFF
--- a/ign_espace_collaboratif/core/EditFormFieldFromAttributes.py
+++ b/ign_espace_collaboratif/core/EditFormFieldFromAttributes.py
@@ -818,14 +818,14 @@ class EditFormFieldFromAttributes(object):
                 if value is None:
                     attribute_values[""] = 'NULL'
                     continue
-                attribute_values[value] = value
+                attribute_values[str(value)] = value
 
         if type(listOfValues) is dict:
             for attribute, value in listOfValues.items():
                 if attribute is None:
                     attribute_values[""] = 'NULL'
                     continue
-                attribute_values[attribute] = value
+                attribute_values[str(attribute)] = value
 
         # Type: ValueMap
         QgsEWS_type = 'ValueMap'
@@ -836,3 +836,4 @@ class EditFormFieldFromAttributes(object):
         if defaultListValue is None or defaultListValue == '':
             defaultListValue = 'NULL'
         self.layer.setDefaultValueDefinition(self.index, QgsDefaultValue("'{}'".format(defaultListValue)))
+


### PR DESCRIPTION
En castant les clés du dictionaire enumere en string, on permet à QGIS de bien initialiser la combobox qui permet de saisir les valeurs d'attribut, même quand ces valeurs sont de type int. En revanche je ne suis pas arrivé à lui faire comprendre un enuméré de type int acceptant les null (c'est autorisé dans postgresql dont tous les types accepte la valeur NULL, mais je n'y arrive pas dans QGIS).