### PR TITLE
ajout au niveau de la suppression des tables afin d'éliminer les meta…

### DIFF
--- a/ign_espace_collaboratif/core/SQLiteManager.py
+++ b/ign_espace_collaboratif/core/SQLiteManager.py
@@ -540,6 +540,29 @@ class SQLiteManager(object):
         SQLiteManager.findAndDeleteLock()
         if not SQLiteManager.isTableExist(tableName):
             return
+        # Nettoyage de la métadonnée SpatiaLite avant de supprimer la table :
+        # si geometry_columns contient encore une entrée pour cette table (cas d'un rechargement
+        # depuis un autre guichet), AddGeometryColumn échoue ou produit un état incohérent
+        # qui peut provoquer un crash QGIS. DiscardGeometryColumn supprime cette entrée.
+        connection = SQLiteManager.sqlite3Connect()
+        try:
+            cur = connection.cursor()
+            cur.execute(
+                "SELECT f_geometry_column FROM geometry_columns WHERE f_table_name = ?",
+                (tableName,)
+            )
+            geom_cols = cur.fetchall()
+            for (geom_col,) in geom_cols:
+                cur.execute(
+                    "SELECT DiscardGeometryColumn(?, ?)",
+                    (tableName, geom_col)
+                )
+            connection.commit()
+            cur.close()
+        except Exception as e:
+            print(f"SQLiteManager.deleteTable : nettoyage geometry_columns ignoré pour {tableName} : {e}")
+        finally:
+            connection.close()
         sql = u"DROP TABLE {0}".format(tableName)
         SQLiteManager.executeSQL(sql)
 


### PR DESCRIPTION
SpatiaLite maintient une table interne geometry_columns qui enregistre chaque couche géométrique (nom de table, nom de colonne, SRID, type...) quand on appelle AddGeometryColumn.

Un simple DROP TABLE supprime la table de données, mais pas la ligne dans geometry_columns. Lors du rechargement depuis un autre guichet, AddGeometryColumn retrouve cette entrée orpheline et produit un état incohérent → crash QGIS.

DiscardGeometryColumn est la fonction SpatiaLite prévue pour nettoyer cette métadonnée avant de supprimer la table. C'est ce qu'on a ajouté dans [deleteTable].